### PR TITLE
Clean up dependencies

### DIFF
--- a/src/ApiVideo.csproj
+++ b/src/ApiVideo.csproj
@@ -69,14 +69,14 @@ The version of the OpenAPI document: 1
     <EnableDefaultItems>true</EnableDefaultItems>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" PrivateAssets="all"/>
     <PackageReference Include="RestSharp" Version="111.2.0" />
-      <PackageReference Include="JsonSubTypes" Version="1.8.0" />
-      <PackageReference Include="NuGet.Build.Tasks.Pack">
+      <!--<PackageReference Include="JsonSubTypes" Version="1.8.0" />-->
+      <!--<PackageReference Include="NuGet.Build.Tasks.Pack" PrivateAssets="all">
         <Version>5.9.1</Version>
-      </PackageReference>
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+      </PackageReference>-->
+    <!--<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />-->
+    <!--<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />-->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Several dependencies are no longer used/needed, or are only needed for build-time tasks and should be removed or removed from the runtime dependencies.